### PR TITLE
Update clients.py

### DIFF
--- a/diskcollections/clients.py
+++ b/diskcollections/clients.py
@@ -26,9 +26,11 @@ class TemporaryFileClient(IClient):
         self.__directory.cleanup()
 
     def __get_file_path(self, key):
-        directory_path = self.__directory.name
-        if 'SSD' in os.environ.keys():
-            directory_path = os.environ['SSD']
+        if os.name == 'nt':
+            if 'SSD' in os.environ.keys():
+                directory_path = os.environ['SSD']
+        else:
+            directory_path = self.__directory.name
         file_path = os.path.join(directory_path, key)
         return file_path
 


### PR DESCRIPTION
create disk file on a different drive i.e. not on the SSD when 'SSD' key exists
to use this option, add this to user program:
 import os
 os.putenv('SSD', dir_name) #replace dir_name with user directory i.e. 'D:\\'
windows only, still working on messy unix version with os.evironb